### PR TITLE
fix: make sure  treeForVendor will resolve dependencies properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,12 +30,20 @@ module.exports = {
   },
 
   treeForVendor(vendorTree) {
-    var fileSaverTree = new Funnel(path.join(this.project.root, 'node_modules', 'file-saver'), {
+    var trees = [];
+    var fileSaverPath = path.dirname(require.resolve('file-saver'));
+    var fileSaverTree = new Funnel(fileSaverPath, {
       files: ['FileSaver.js']
     });
 
     fileSaverTree = map(fileSaverTree, (content) => `if (typeof FastBoot === 'undefined') { ${content} }`);
 
-    return new MergeTrees([vendorTree, fileSaverTree]);
+    if (vendorTree !== undefined) {
+      trees.push(vendorTree);
+    }
+
+    trees.push(fileSaverTree);
+
+    return new MergeTrees(trees);
   },
 };


### PR DESCRIPTION
Hello,

I have changed `treeForVendor` hook implementation a bit. 

It will basically improve the way how add-on is resolving dependencies. It won't affect or change anything in the small projects where dependencies are stored in the root folder... 

But, it will definitely help people like me who are working on quite complex codebases like [monorepos](https://github.com/babel/babel/blob/master/doc/design/monorepo.md) where dependencies are shared between all the apps in one ecosystem.

Cheers ✌️ 