### PR TITLE
Prevent .node_modules.ember-try from being npm published

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,4 @@
 bower.json
 ember-cli-build.js
 testem.js
+.node_modules.ember-try


### PR DESCRIPTION
add .node_modules.ember-try .npmignore to prevent it from being npm published.