### PR TITLE
chore(deps): upgrade file-saver to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-stew": "^1.5.0",
     "ember-cli-babel": "^6.3.0",
-    "file-saver": "1.3.3"
+    "file-saver": "2.0.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",


### PR DESCRIPTION
I locked the dependency to `2.0.0`.

I was unable to get package-lock.json to update without unlocking (adding ^) all other dependencies and doing other small upgrades. So I left that to be done by someone who is familiar with it.